### PR TITLE
Link to GitHub compare view when showing commits behind main

### DIFF
--- a/src/components/repo_list/release_state.js
+++ b/src/components/repo_list/release_state.js
@@ -60,19 +60,26 @@ export default class ReleaseState extends React.Component<Props, State> {
     }
 
     return (
-      <ExternalLink
+      <div
         className='release-state'
-        href={`${this.props.repo.url}/releases`}
         aria-label='release-state'
       >
-        <div className='tag' aria-label='tag'>
+        <ExternalLink
+          className='tag'
+          aria-label='tag'
+          href={`${this.props.repo.url}/releases`}
+        >
           {this.state.release.tag}
-        </div>
-        <div className={commitsClass} aria-label='commits-behind'>
+        </ExternalLink>
+        <ExternalLink
+          className={commitsClass}
+          aria-label='commits-behind'
+          href={`${this.props.repo.url}/compare/${this.state.release.tag}...main`}
+        >
           {this.state.release.commitsBehind}
           <GitCommitIcon size={16} />
-        </div>
-      </ExternalLink>
+        </ExternalLink>
+      </div>
     );
   }
 }

--- a/src/components/repo_list/release_state.test.js
+++ b/src/components/repo_list/release_state.test.js
@@ -57,27 +57,23 @@ describe('ReleaseState', () => {
       );
     });
 
-    it('renders the node as a link to the repo releases', () => {
-      const node = result.getByRole('link', { name: 'release-state' });
-
-      expect(node).toHaveAttribute('href', 'some-repo-url/releases');
-    });
-
     it('renders the tag of the release', () => {
-      const tag = result.getByRole('generic', { name: 'tag' });
+      const tag = result.getByRole('link', { name: 'tag' });
       expect(tag).toHaveTextContent(/v1\.2\.3/i);
+      expect(tag).toHaveAttribute('href', 'some-repo-url/releases');
     });
 
     it('renders the number of commits since the release', () => {
-      const count = result.getByRole('generic', { name: 'commits-behind' });
+      const count = result.getByRole('link', { name: 'commits-behind' });
       expect(count).toHaveTextContent(/2/i);
       expect(count).toHaveClass('behind');
+      expect(count).toHaveAttribute('href', 'some-repo-url/compare/v1.2.3...main');
     });
   });
 
   describe('when the promise is not resolved', () => {
     it('renders an emdash', () => {
-      const tag = result.getByRole('generic', { name: 'tag' });
+      const tag = result.getByRole('link', { name: 'tag' });
       expect(tag).toHaveTextContent(/—/i);
     });
   });
@@ -99,12 +95,12 @@ describe('ReleaseState', () => {
     });
 
     it('renders the tag of the release', () => {
-      const tag = result.getByRole('generic', { name: 'tag' });
+      const tag = result.getByRole('link', { name: 'tag' });
       expect(tag).toHaveTextContent(/v1\.2\.3/i);
     });
 
     it('renders the number of commits since the release', () => {
-      const count = result.getByRole('generic', { name: 'commits-behind' });
+      const count = result.getByRole('link', { name: 'commits-behind' });
       expect(count).toHaveTextContent(/0/i);
       expect(count).not.toHaveClass('behind');
     });

--- a/src/components/repo_list/repo_item.test.js
+++ b/src/components/repo_list/repo_item.test.js
@@ -54,7 +54,7 @@ describe('RepoItem', () => {
   });
 
   it('renders the release state', () => {
-    const latestRelease = result.getByRole('link', { name: 'release-state' });
+    const latestRelease = result.getByRole('generic', { name: 'release-state' });
     expect(latestRelease).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When clicking on the UI element showing the number of commits behind `main`, you will open a new tab showing a "compare view" between the latest release tag and what it currently on `main`. This is a good overview of the diff that would be released if you cut a release at this time.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
