### PR TITLE
Use the paketo-bot token to checkout the repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         ref: gh-pages
 
     - name: Checkout build environment


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We currently can't deploy because we setup a branch protection rule that our deploy workflow does not obey: https://github.com/paketo-buildpacks/dashboard/runs/2005691025. This PR should hopefully configure the checked out repo to commit as the `paketo-bot` so that we can push to the protected `gh-pages` branch.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
