### PR TITLE
Display time since last release

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "@testing-library/user-event": "13.5.0",
     "flow-bin": "0.184.0",
     "luxon": "3.0.4",
+    "moment": "2.29.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "5.3.0",

--- a/web/src/components/repo_list/release_state.js
+++ b/web/src/components/repo_list/release_state.js
@@ -8,6 +8,7 @@ import { type ReleaseStoreInterface } from '../../stores/release_store';
 import { type CacheInterface } from '../../lib/cache';
 
 import ExternalLink from '../lib/external_link';
+import moment from 'moment';
 import { GitCommitIcon } from '@primer/octicons-react';
 
 import '../../styles/repo_list/release_state.css';
@@ -59,10 +60,16 @@ export default class ReleaseState extends React.Component<Props, State> {
       commitsClass += ' behind';
     }
 
+    let lastReleaseTime = "never released";
+    if(this.state.release.createdAt) {
+      lastReleaseTime = `released ${moment(this.state.release.createdAt).fromNow()}`;
+    }
+
     return (
       <div
         className='release-state'
         aria-label='release-state'
+        title={lastReleaseTime}
       >
         <ExternalLink
           className='tag'

--- a/web/src/components/repo_list/release_state.test.js
+++ b/web/src/components/repo_list/release_state.test.js
@@ -44,6 +44,7 @@ describe('ReleaseState', () => {
         release: {
           tag: 'v1.2.3',
           commitsBehind: 2,
+          createdAt: new Date(),
         },
       });
 
@@ -69,12 +70,22 @@ describe('ReleaseState', () => {
       expect(count).toHaveClass('behind');
       expect(count).toHaveAttribute('href', 'some-repo-url/compare/v1.2.3...main');
     });
+
+    it('renders tooltip', () => {
+      const root = result.container.firstElementChild;
+      expect(result.container.firstElementChild).toHaveAttribute('title');
+    });
   });
 
   describe('when the promise is not resolved', () => {
     it('renders an emdash', () => {
       const tag = result.getByRole('link', { name: 'tag' });
       expect(tag).toHaveTextContent(/—/i);
+    });
+
+    it('tooltip says "never released"', () => {
+      const root = result.container.firstElementChild;
+      expect(result.container.firstElementChild).toHaveAttribute('title', 'never released');
     });
   });
 
@@ -83,6 +94,7 @@ describe('ReleaseState', () => {
       resolveLatestRelease(new Release({
         tag: 'v1.2.3',
         commitsBehind: 0,
+        createdAt: new Date(),
       }))
 
       result.rerender(
@@ -103,6 +115,11 @@ describe('ReleaseState', () => {
       const count = result.getByRole('link', { name: 'commits-behind' });
       expect(count).toHaveTextContent(/0/i);
       expect(count).not.toHaveClass('behind');
+    });
+
+    it('renders tooltip', () => {
+      const root = result.container.firstElementChild;
+      expect(result.container.firstElementChild).toHaveAttribute('title');
     });
   });
 });

--- a/web/src/models/release.js
+++ b/web/src/models/release.js
@@ -3,15 +3,18 @@
 type Props = {|
   tag: string,
   commitsBehind: number,
+  createdAt?: Date,
 |};
 
 export default class Release {
   tag: string;
   commitsBehind: number;
+  createdAt: ?Date;
 
   constructor(props: Props) {
     this.tag = props.tag;
     this.commitsBehind = props.commitsBehind;
+    this.createdAt = props.createdAt;
   }
 }
 

--- a/web/src/stores/release_store.js
+++ b/web/src/stores/release_store.js
@@ -23,6 +23,7 @@ export default class ReleaseStore {
     let release = NullRelease;
     if (response.status === 200) {
       const tagName = (response.data: { [string]: any })['tag_name'];
+      const createdAt = (response.data: { [string]: any })['created_at'];
 
       response = await this.client.do({
         method: 'GET',
@@ -34,6 +35,7 @@ export default class ReleaseStore {
       release = new Release({
         tag: tagName,
         commitsBehind: behindBy,
+        createdAt: createdAt,
       });
     }
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7060,6 +7060,11 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment@2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

Show the last release time (or "never released") when hovering over release details.
It uses the moment library to display human readable time deltas (e.g. "2 months ago", "3 days ago")

Notice: In the screenshots you can't see my cursor, as Ubuntu seems to "helpfully" hide them from the Screenshot. 

![image](https://user-images.githubusercontent.com/24714828/197245022-943d1ffa-071f-4486-a4fd-946082592b7d.png)

![image](https://user-images.githubusercontent.com/24714828/197245254-f1eeaa25-94e8-4120-b0ab-696c5d0b618c.png)



## Use Cases
<!-- An explanation of the use cases your change enables -->

Fixes #9


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
