### PR TITLE
ignore archived repos

### DIFF
--- a/web/src/stores/repo_store.js
+++ b/web/src/stores/repo_store.js
@@ -25,6 +25,9 @@ export default class RepoStore {
       });
 
       for (const repo of response.data) {
+        if(repo.archived) {
+          continue;
+        }
         repos.push(new Repo({
           id: repo.id,
           name: repo.full_name,

--- a/web/src/stores/repo_store.test.js
+++ b/web/src/stores/repo_store.test.js
@@ -25,6 +25,7 @@ describe('RepoStore', () => {
               full_name: 'some-org/first-repo',
               html_url: 'first-repo-url',
               open_issues_count: 1,
+              archived: false,
             },
             {
               id: 2222,
@@ -32,6 +33,15 @@ describe('RepoStore', () => {
               full_name: 'some-org/second-repo',
               html_url: 'second-repo-url',
               open_issues_count: 2,
+              archived: false,
+            },
+            {
+              id: 1234,
+              name: 'archived-repo',
+              full_name: 'some-org/archived-repo',
+              html_url: 'archived-repo-url',
+              open_issues_count: 42,
+              archived: true,
             },
           ],
           headers: {
@@ -47,6 +57,7 @@ describe('RepoStore', () => {
               full_name: 'some-org/third-repo',
               html_url: 'third-repo-url',
               open_issues_count: 3,
+              archived: false,
             },
             {
               id: 4444,
@@ -54,6 +65,7 @@ describe('RepoStore', () => {
               full_name: 'some-org/fourth-repo',
               html_url: 'fourth-repo-url',
               open_issues_count: 4,
+              archived: false,
             },
           ],
           headers: {


### PR DESCRIPTION
## Summary

Ignore any archived repo.

Unfortunately the filtering happens client-side. The [GitHub Repositories REST API](https://docs.github.com/en/rest/repos/repos#list-organization-repositories) does not support excluding archived repos.
We could switch to either the [Search API](https://docs.github.com/en/rest/search#search-repositories) or the [GraphQL API](https://docs.github.com/en/graphql), but I guess it's not worth it.

## Use Cases

Fixes #141

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
